### PR TITLE
Fixed some problems in the library

### DIFF
--- a/src/NConsole.Tests/CommandLineProcessorTests.cs
+++ b/src/NConsole.Tests/CommandLineProcessorTests.cs
@@ -8,6 +8,27 @@ namespace NConsole.Tests
     public class CommandLineProcessorTests
     {
         [Fact]
+        public void When_using_default_help_is_in_the_commands_list()
+        {
+            //// Arrange
+            var processor = new CommandLineProcessor(new ConsoleHost(), new MyDependencyResolver());
+
+            //// Assert
+            Assert.True(processor.Commands.ContainsKey("help"));
+        }
+
+        [Fact]
+        public void When_not_using_default_help_is_not_in_the_commands_list()
+        {
+            //// Arrange
+            var processor = new CommandLineProcessor(new ConsoleHost(), new MyDependencyResolver(), false);
+
+            //// Assert
+            Assert.False(processor.Commands.ContainsKey("help"));
+        }
+
+
+        [Fact]
         public void When_adding_a_command_then_the_command_is_in_the_commands_list()
         {
             //// Arrange

--- a/src/NConsole.Tests/UnexpectedArgumentsTests.cs
+++ b/src/NConsole.Tests/UnexpectedArgumentsTests.cs
@@ -43,7 +43,7 @@ namespace NConsole.Tests
 
             //// Assert
             var exception = await Assert.ThrowsAsync<UnusedArgumentException>(async () => await ProcessAsyncThrowsException());
-            Assert.Equal("Unrecognised arguments are present: [12:13:14]", exception.Message);
+            Assert.Equal("Unrecognised arguments are present: [Used arguments (3) != Provided arguments (4) -> Check [12:13:14]]", exception.Message);
         }
 
         [Fact]
@@ -62,7 +62,7 @@ namespace NConsole.Tests
 
             //// Assert
             var exception = await Assert.ThrowsAsync<UnusedArgumentException>(async () => await ProcessAsyncThrowsException());
-            Assert.Equal("Unrecognised arguments are present: [second, /third:third, /Fourth]", exception.Message);
+            Assert.Equal("Unrecognised arguments are present: [Used arguments (1) != Provided arguments (4) -> Check [second, /third:third, /Fourth]]", exception.Message);
         }
 
         public class MyArgumentCommand : IConsoleCommand

--- a/src/NConsole/ConsoleHost.cs
+++ b/src/NConsole/ConsoleHost.cs
@@ -8,6 +8,7 @@ namespace NConsole
     {
         private readonly Type _consoleType = typeof(Console);
         private readonly MethodInfo _consoleWriteMethod;
+        private readonly MethodInfo _consoleWriteLineMethod;
         private readonly MethodInfo _consoleReadLineMethod;
         private readonly PropertyInfo _consoleForegroundColorProperty;
 
@@ -15,6 +16,7 @@ namespace NConsole
         public ConsoleHost()
         {
             _consoleWriteMethod = _consoleType.GetRuntimeMethod("Write", new[] { typeof(string) });
+            _consoleWriteLineMethod = _consoleType.GetRuntimeMethod("WriteLine", new[] { typeof(string) });
             _consoleReadLineMethod = _consoleType.GetRuntimeMethod("ReadLine", new Type[] { });
             _consoleForegroundColorProperty = _consoleType.GetRuntimeProperty("ForegroundColor");
         }
@@ -36,6 +38,14 @@ namespace NConsole
         {
             _consoleWriteMethod.Invoke(null, new object[] { message });
         }
+
+        /// <summary>Writes a line to the console.</summary>
+        /// <param name="line">The line.</param>
+        public void WriteLine(string line)
+        {
+            _consoleWriteLineMethod.Invoke(null, new object[] { line });
+        }
+
 
         /// <summary>Writes an error message to the console.</summary>
         /// <param name="message">The message.</param>

--- a/src/NConsole/HelpCommand.cs
+++ b/src/NConsole/HelpCommand.cs
@@ -13,6 +13,11 @@ namespace NConsole
         [Argument(Position = 1, IsRequired = false, ShowPrompt = false)]
         public string Command { get; set; }
 
+        /// <summary>
+        /// Usage line of help command.
+        /// </summary>
+        public string Usage { get; set; } = "  myapp.exe myCommand /myParameter:myValue /mySecondParameter:myValue\n\n";
+
         /// <summary>Runs the command.</summary>
         /// <param name="processor">The processor.</param>
         /// <param name="host">The host.</param>
@@ -30,23 +35,36 @@ namespace NConsole
             {
                 host.WriteMessage("\n");
                 host.WriteMessage("Usage:\n\n");
-                host.WriteMessage("  myapp.exe myCommand /myParameter:myValue /mySecondParameter:myValue\n\n");
+                host.WriteMessage(Usage);
                 host.WriteMessage("Commands:\n\n");
                 foreach (var command in processor.Commands.Where(c => c.Key != "help"))
                     host.WriteMessage("  " + command.Key + "\n");
-                host.ReadValue("Press <enter> key to show commands...");
+
+                PromptInteractiveOnly(host, "Press <enter> key to show commands...");
 
                 foreach (var command in processor.Commands)
                 {
                     if (command.Key != "help")
                     {
                         PrintCommand(host, command);
-                        host.ReadValue("Press <enter> key for next command...");
+                        PromptInteractiveOnly(host, "Press <enter> key for next command...");
                     }
                 }
             }
 
             return Task.FromResult<object>(null);
+        }
+
+        /// <summary>
+        /// Prompt user to press a key before continuing
+        /// </summary>
+        /// <param name="message">Message to display</param>
+        private static void PromptInteractiveOnly(IConsoleHost host, string message)
+        {
+            if (host.InteractiveMode)
+            {
+                host.ReadValue(message);
+            }
         }
 
         private void PrintCommand(IConsoleHost host, KeyValuePair<string, Type> pair)

--- a/src/NConsole/IConsoleHost.cs
+++ b/src/NConsole/IConsoleHost.cs
@@ -7,6 +7,10 @@ namespace NConsole
         /// <param name="message">The message.</param>
         void WriteMessage(string message);
 
+        /// <summary>Writes a line to the console.</summary>
+        /// <param name="line">The line.</param>
+        void WriteLine(string line);
+
         /// <summary>Writes an error message.</summary>
         /// <param name="message">The message.</param>
         void WriteError(string message);
@@ -15,5 +19,8 @@ namespace NConsole
         /// <param name="message">The message.</param>
         /// <returns>The value.</returns>
         string ReadValue(string message);
+
+        /// <summary>Gets or sets a value indicating whether interactive mode is enabled (i.e. ReadValue() is allowed).</summary>
+        bool InteractiveMode { get; }
     }
 }

--- a/src/NConsole/NConsole.csproj
+++ b/src/NConsole/NConsole.csproj
@@ -6,7 +6,7 @@
     <VersionPrefix>3.12.6605.26941</VersionPrefix>
     <Authors>Rico Suter</Authors>
     <Copyright>Copyright © Rico Suter, 2016</Copyright>
-    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.3;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PlatformTarget>anycpu</PlatformTarget>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
Hi,

I've fixed the problems regarding the argument handling and did some other minor changes.
Please have a look.

 * Input of command name in interactive mode now works correctly
 * Bugfix in IConsoleHost: Added property InteractiveMode to IConsoleHost, because commands need to be able to check if command mode is interactive
 * Bugfix in help command: The help command now only reads something from the console, if running in interactive mode
 * Minor changes in help command
   * Add argument to prevent CommandLineProcessor from creating 'default' help command
   * Added Usage parameter to help command (simple customization option is to derivce from help command and then not registering default help)


The pull request contains 2 breaking changes for applications implementing IConsoleHost 
 * Added "WriteLine" to IConsoleHost because using Write and always adding "\n" really annoyed me.
 * Added property InteractiveMode (as in ConsoleHost)

Cheers
